### PR TITLE
Use NVIDIA docker mirror

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -149,6 +149,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-config: /etc/buildkit/buildkitd.toml
 
       # build-container warms the GHA layer cache (push:false, no load), leaving
       # no runnable image; rebuild the builder target here with load:true (cache
@@ -205,6 +207,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-config: /etc/buildkit/buildkitd.toml
 
       # The build-container job (dsx docker-build action) builds this same
       # target with push:false, which only warms the GHA layer cache — it leaves
@@ -277,6 +281,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-config: /etc/buildkit/buildkitd.toml
 
       # Same local-build-then-run pattern as lint-police / test: build-container
       # only warms the cache, so rebuild the builder target with load:true.
@@ -364,6 +370,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-config: /etc/buildkit/buildkitd.toml
 
       # Rebuild the builder target locally (cache hit) so `cargo bench` can run
       # inside it — same local-build-then-run pattern as lint-police / test.
@@ -423,6 +431,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-config: /etc/buildkit/buildkitd.toml
 
       - name: Build release image (${{ matrix.arch }})
         uses: docker/build-push-action@v6
@@ -455,6 +465,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-config: /etc/buildkit/buildkitd.toml
 
       - name: Log in to registry
         uses: ./.github/actions/docker-auth
@@ -489,6 +501,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-config: /etc/buildkit/buildkitd.toml
 
       - name: Log in to registry
         uses: ./.github/actions/docker-auth


### PR DESCRIPTION
# Pull Request
A [Docker mirror](https://docs.docker.com/docker-hub/image-library/mirror/) is deployed in each environment (AWS & on-premise) to cache Docker image layers. The Docker daemon on our runners is configured to use it by default, but it must be manually configured for BuildKit.

## Related Issues

<!-- Link related GitHub issues here. Use "Fixes #123" when this PR should close an issue. -->

## Type Of Change

<!-- Check one that best describes this PR. -->

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes such as refactoring, tests, docs, or tooling

## Breaking Changes

<!-- If checked, describe the breaking changes and migration steps. -->
<!-- Breaking changes are not generally permitted without discussion with the development team. -->

- [ ] **This PR contains breaking changes**

## Testing

<!-- Check all that apply. -->

- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Manual testing performed
- [ ] No testing required

## QA And Release Notes

<!-- Add QA guidance, validation notes, and release-note impact. -->

- QA owner:
- Test plan:
- Release note:

## Additional Notes

<!-- Add deployment notes, reviewer guidance, known follow-ups, or other context. -->
