### PR TITLE
chore: repoint CODEOWNERS teams to dsx-ai-factory after SCM transfer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,16 +4,16 @@
 # Rules are evaluated from top to bottom, with later rules taking precedence.
 
 # Default owners for everything in the repo
-* @NVIDIA/rms-sw-contributors
+* @dsx-ai-factory/rms-sw-contributors
 
 # GitHub process and automation files
-/.github/ @NVIDIA/dsx-sw-cicd @NVIDIA/rms-sw-admins
+/.github/ @dsx-ai-factory/dsx-sw-cicd @dsx-ai-factory/rms-sw-admins
 
 # CODEOWNERS file itself - requires admin approval
-/.github/CODEOWNERS @NVIDIA/rms-sw-admins
+/.github/CODEOWNERS @dsx-ai-factory/rms-sw-admins
 
 # Helm charts
-/helm/ @NVIDIA/dsx-sw-helm
+/helm/ @dsx-ai-factory/dsx-sw-helm
 
 # Security policy
-/SECURITY.md @NVIDIA/rms-sw-admins
+/SECURITY.md @dsx-ai-factory/rms-sw-admins


### PR DESCRIPTION
## What

Rewrites the CODEOWNERS team references from `@NVIDIA/*` to `@dsx-ai-factory/*`
now that `nv-rms` has transferred to the `dsx-ai-factory` org:

- `@NVIDIA/rms-sw-contributors` -> `@dsx-ai-factory/rms-sw-contributors`
- `@NVIDIA/rms-sw-admins`       -> `@dsx-ai-factory/rms-sw-admins`
- `@NVIDIA/dsx-sw-cicd`         -> `@dsx-ai-factory/dsx-sw-cicd`
- `@NVIDIA/dsx-sw-helm`         -> `@dsx-ai-factory/dsx-sw-helm`

## Why

Team handles are org-scoped. After the SCM transfer the old `@NVIDIA/*` team
references no longer resolve, so code-owner auto-requests silently stopped
working. All four teams have been (re-)granted repo access in `dsx-ai-factory`
(`rms-sw-*` restored from the pre-transfer backup; `dsx-sw-cicd`/`dsx-sw-helm`
granted read so their code-owner rules resolve).

## Notes

- No rule/path changes; only the org prefix on team handles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code ownership assignments to use the new owner groups while preserving existing path coverage and responsibilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->