### PR TITLE
chore: add GitHub Actions docs CI pipeline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -667,21 +667,6 @@ jobs:
           post-pr-comment: 'false'
           fail-on-findings: 'true'
 
-  markdownlint:
-    name: Markdown Lint
-    needs: prepare
-    runs-on: linux-amd64-cpu4
-    timeout-minutes: 15
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-      - name: Run markdownlint-cli2
-        run: |
-          docker run --rm -v "${{ github.workspace }}:/workdir" \
-            davidanson/markdownlint-cli2:v0.17.2 "**/*.md"
-
   # Slack notification via nico's ported reusable workflow. Runs after every job
   # (always()), so it fires on all three triggers this workflow allows: PR
   # (pull-request/*), main, and tags. Overall status is computed from the needs
@@ -692,7 +677,7 @@ jobs:
 
   # TODO: Uncomment when the app is approved for slack notifications
   # notify:
-  #   needs: [prepare, build-container-x86_64, build-container-aarch64, lint-police, test, coverage, build-release, publish-image, publish-manifest, helm-validate, helm-publish, security-codeql-scan, security-secret-scan, markdownlint]
+  #   needs: [prepare, build-container-x86_64, build-container-aarch64, lint-police, test, coverage, build-release, publish-image, publish-manifest, helm-validate, helm-publish, security-codeql-scan, security-secret-scan]
   #   if: ${{ always() }}
   #   uses: ./.github/workflows/notify-build-status.yml
   #   with:
@@ -707,7 +692,7 @@ jobs:
   #     slack-bot-token: ${{ secrets.RMS_SLACK_BOT_TOKEN }}
 
   core-ci-pass:
-    needs: [prepare, build-container-x86_64, build-container-aarch64, lint-police, test, coverage, build-release, publish-image, publish-manifest, helm-validate, helm-publish, security-codeql-scan, security-secret-scan, markdownlint]
+    needs: [prepare, build-container-x86_64, build-container-aarch64, lint-police, test, coverage, build-release, publish-image, publish-manifest, helm-validate, helm-publish, security-codeql-scan, security-secret-scan]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/cleanup-preview.yaml
+++ b/.github/workflows/cleanup-preview.yaml
@@ -1,0 +1,41 @@
+name: Clean Up Preview Links
+
+# Companion to preview-docs.yaml, following Fern's reference workflow at
+# https://buildwithfern.com/learn/docs/preview-publish/preview-changes#preview-links
+# Deletes the preview under the same `--id` (the head branch name) that
+# preview-docs.yaml generated it with. Fern previews never expire on their own.
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  cleanup:
+    name: Delete Preview
+    # Only merged PRs from this repo ever produced a preview to clean up.
+    if: >-
+      ${{ github.event.pull_request.merged == true
+          && github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: linux-amd64-cpu4
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Fern CLI
+        uses: fern-api/setup-fern-cli@v1
+
+      - name: Delete preview deployment
+        env:
+          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          echo "Deleting preview for branch: $HEAD_REF"
+          fern docs preview delete --id "$HEAD_REF" \
+            || echo "Preview deletion returned non-zero - it may already be gone"

--- a/.github/workflows/lint-docs.yaml
+++ b/.github/workflows/lint-docs.yaml
@@ -1,0 +1,44 @@
+name: Lint Docs
+
+# Trigger mirrors ci.yaml: `pull-request/<number>` are the branches the
+# copy-pr-bot app mirrors PRs onto, which is how PRs from forks get linted.
+#
+# Deliberately has no `paths` filter, unlike preview-docs.yaml: a skipped
+# path-filtered workflow reports no status at all, which would deadlock any PR
+# that made this a required check without touching docs.
+on:
+  push:
+    branches:
+      - main
+      - "pull-request/[0-9]+"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lint-docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint Docs
+    runs-on: linux-amd64-cpu4
+    timeout-minutes: 15
+    env:
+      FERN_NO_VERSION_REDIRECTION: "true"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      # No setup-fern-cli here: docs-lint.sh pins its own fern and rumdl
+      # versions through npx, so this only needs Node on the PATH. That keeps
+      # the script the single source of truth for CI and `just docs-lint`.
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - name: Lint docs site
+        run: ./scripts/docs-lint.sh

--- a/.github/workflows/preview-docs.yaml
+++ b/.github/workflows/preview-docs.yaml
@@ -1,0 +1,118 @@
+name: Preview Docs
+
+# Follows the reference workflow Fern publishes at
+# https://buildwithfern.com/learn/docs/preview-publish/preview-changes#preview-links
+#
+# The preview is keyed on the head branch name, so every push to a PR updates
+# the same URL, and cleanup-preview.yaml deletes it under that same id on merge.
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+    branches:
+      - main
+    # Safe to filter here, unlike the required docs-lint check in docs.yaml: a
+    # skipped preview reports no status, and nothing gates on it.
+    paths:
+      - "docs/**"
+      - "fern/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: preview-docs-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    name: Preview Docs
+    # Fork PRs cannot read FERN_TOKEN on a `pull_request` event, so skip them
+    # rather than fail them red. Fern's answer to this is `pull_request_target`,
+    # which is deliberately not used here (it would run fork code with secrets).
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: linux-amd64-cpu4
+    timeout-minutes: 30
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0  # origin/main...HEAD diff for the changed-page links
+
+      - name: Setup Fern CLI
+        uses: fern-api/setup-fern-cli@v1
+
+      - name: Generate preview URL
+        id: generate-docs
+        env:
+          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+          FERN_NO_VERSION_REDIRECTION: "true"
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          OUTPUT=$(fern generate --docs --preview --id "$HEAD_REF" 2>&1) || true
+          echo "$OUTPUT"
+          URL=$(echo "$OUTPUT" | grep -oP 'Published docs to \K.*(?= \()' || true)
+          # `fern generate` failures are swallowed above, so a missing URL is
+          # the real signal that the preview did not publish.
+          if [ -z "$URL" ]; then
+            echo "::error::Fern did not report a published preview URL"
+            exit 1
+          fi
+          echo "preview_url=$URL" >> "$GITHUB_OUTPUT"
+          echo "Preview URL: $URL"
+
+      - name: Get page links for changed pages
+        id: page-links
+        env:
+          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+          PREVIEW_URL: ${{ steps.generate-docs.outputs.preview_url }}
+        run: |
+          # RMS docs pages are .md, not the .mdx Fern's reference workflow
+          # assumes, and only docs/ and fern/ hold site content.
+          CHANGED_FILES=$(git diff --name-only origin/main...HEAD -- docs fern \
+            | grep -E '\.mdx?$' || echo "")
+
+          if [ -z "$CHANGED_FILES" ] || [ -z "$PREVIEW_URL" ]; then
+            echo "page_links=" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+
+          BASE_URL=$(echo "$PREVIEW_URL" | grep -oP 'https?://[^/]+')
+
+          FILES_PARAM=$(echo "$CHANGED_FILES" | tr '\n' ',' | sed 's/,$//')
+          RESPONSE=$(curl -sf -H "FERN_TOKEN: $FERN_TOKEN" "${PREVIEW_URL}/api/fern-docs/get-slug-for-file?files=${FILES_PARAM}" 2>/dev/null) || {
+            echo "page_links=" >> "$GITHUB_OUTPUT"; exit 0
+          }
+
+          PAGE_LINKS=$(echo "$RESPONSE" | jq -r --arg url "$BASE_URL" \
+            '.mappings[] | select(.slug != null) | "- [\(.slug)](\($url)/\(.slug))"')
+
+          if [ -n "$PAGE_LINKS" ]; then
+            { echo "page_links<<EOF"; echo "$PAGE_LINKS"; echo "EOF"; } >> "$GITHUB_OUTPUT"
+          else
+            echo "page_links=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create comment content
+        env:
+          PREVIEW_URL: ${{ steps.generate-docs.outputs.preview_url }}
+          PAGE_LINKS: ${{ steps.page-links.outputs.page_links }}
+        run: |
+          echo ":herb: **Preview your docs:** <${PREVIEW_URL}>" > comment.md
+
+          if [ -n "$PAGE_LINKS" ]; then
+            {
+              echo ""
+              echo "Here are the markdown pages you've updated:"
+              echo "$PAGE_LINKS"
+            } >> comment.md
+          fi
+
+      - name: Post PR comment
+        uses: thollander/actions-comment-pull-request@v2.4.3
+        with:
+          filePath: comment.md
+          comment_tag: preview-docs
+          mode: upsert

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -1,0 +1,48 @@
+name: Publish Docs
+
+# Follows the reference workflow Fern publishes at
+# https://buildwithfern.com/learn/docs/preview-publish/publishing-your-docs
+#
+# fern/docs.yml declares a single instance, so this is the "publish to
+# production" shape: no `--instance` flag and no staging site.
+on:
+  push:
+    branches:
+      - main
+  # Lets a failed or superseded publish be re-run from the Actions tab without
+  # an empty commit, as in Fern's staging/production examples.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-docs
+  cancel-in-progress: false  # never cancel a publish mid-flight
+
+jobs:
+  publish:
+    name: Publish Docs
+    runs-on: linux-amd64-cpu4
+    timeout-minutes: 30
+    env:
+      FERN_NO_VERSION_REDIRECTION: "true"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Fern CLI
+        uses: fern-api/setup-fern-cli@v1
+
+      # Fern's staging and production examples both validate before publishing.
+      # This is the stricter form the lint workflow runs, as a last gate before
+      # the site goes live.
+      - name: Validate configuration
+        run: fern check --broken-links --local --warnings
+
+      - name: Publish Docs
+        env:
+          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+        run: fern generate --docs

--- a/Justfile
+++ b/Justfile
@@ -59,7 +59,7 @@ docker-build-builder image="rms-builder" context=".":
 docs-api:
     RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
 
-# Docs-site checks; same script CI's lint_docs job runs.
+# Docs-site checks; same script CI's Lint Docs workflow runs.
 docs-lint:
     ./scripts/docs-lint.sh
 

--- a/fern/README.md
+++ b/fern/README.md
@@ -39,6 +39,36 @@ var before running `fern docs dev`:
 export NODE_OPTIONS="--experimental-sqlite"
 ```
 
+## Continuous Integration
+
+Four workflows cover the docs site, each following the reference workflow Fern
+publishes under
+[Preview changes](https://buildwithfern.com/learn/docs/preview-publish/preview-changes#preview-links)
+or
+[Publishing your docs](https://buildwithfern.com/learn/docs/preview-publish/publishing-your-docs).
+
+| Workflow | Trigger | Purpose |
+| --- | --- | --- |
+| [`lint-docs.yaml`](../.github/workflows/lint-docs.yaml) | Push to `main` or `pull-request/<number>` | Runs [`scripts/docs-lint.sh`](../scripts/docs-lint.sh), the same checks as `just docs-lint` |
+| [`preview-docs.yaml`](../.github/workflows/preview-docs.yaml) | `pull_request` against `main`, touching `docs/` or `fern/` | Publishes a preview and upserts a pull request comment with the URL plus deep links to every changed page |
+| [`cleanup-preview.yaml`](../.github/workflows/cleanup-preview.yaml) | `pull_request` closed | Deletes the preview when the pull request merged |
+| [`publish-docs.yaml`](../.github/workflows/publish-docs.yaml) | Push to `main`, or manual dispatch | Validates the site, then publishes it live |
+
+Previews are keyed on the head branch name, so every push to a pull request
+updates the same URL and `cleanup-preview.yaml` deletes it under that same id on
+merge. Fern previews never expire on their own, which is why the cleanup
+workflow exists.
+
+`fern/docs.yml` declares a single instance, so `publish-docs.yaml` publishes
+straight to production with no `--instance` flag and no staging site. It can be
+re-run by hand from the Actions tab.
+
+Every workflow except `lint-docs.yaml` authenticates to Fern with the
+`FERN_TOKEN` repository secret. Because `pull_request` does not expose secrets
+to forks, the preview and cleanup workflows skip pull requests opened from a
+fork; linting still runs on those through the mirrored
+`pull-request/<number>` branch.
+
 ## Layout
 
 | Path | Purpose |

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -29,7 +29,7 @@ ai-search:
 navbar-links:
   - type: filled
     text: GitHub
-    href: https://github.com/NVIDIA/nv-rms
+    href: https://github.com/dsx-ai-factory/nv-rms
 
 tabs:
   documentation:

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1,12 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
-#
-# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
-# property and proprietary rights in and to this material, related
-# documentation and any modifications thereto. Any use, reproduction,
-# disclosure or distribution of this material and related documentation
-# without an express license agreement from NVIDIA CORPORATION or
-# its affiliates is strictly prohibited.
+# SPDX-License-Identifier: Apache-2.0
 
 # yaml-language-server: $schema=https://schema.buildwithfern.dev/docs-yml.json
 
@@ -19,17 +12,16 @@ instances:
 
 title: NVIDIA Rack Management Service
 
-metadata:
-  canonical-host: "docs.nvidia.com"
+# metadata:
+#   canonical-host: "docs.nvidia.com/rms"
 
-ai-search:
-  location:
-    - docs
+check:
+  rules:
+    broken-links: error
 
 navbar-links:
-  - type: filled
-    text: GitHub
-    href: https://github.com/dsx-ai-factory/nv-rms
+  - type: github
+    value: https://github.com/dsx-ai-factory/nv-rms
 
 tabs:
   documentation:

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "nvidia",
-  "version": "5.57.0"
+  "version": "5.102.0"
 }


### PR DESCRIPTION
# Description

Adds the docs CI pipeline for the Fern site as four single-purpose GitHub
Actions workflows, porting the GitLab `lint_docs`, `preview_docs`, and
`publish_docs` jobs and following the reference workflows Fern publishes
under [Preview changes](https://buildwithfern.com/learn/docs/preview-publish/preview-changes#preview-links)
and [Publishing your docs](https://buildwithfern.com/learn/docs/preview-publish/publishing-your-docs).

| Workflow | Trigger | What it does |
| --- | --- | --- |
| `lint-docs.yaml` | Push to `main` or `pull-request/<n>` | Runs `scripts/docs-lint.sh` (self-closing `<img>` check, `fern check`, `fern check --broken-links`, `rumdl check .`) |
| `preview-docs.yaml` | `pull_request` against `main`, touching `docs/` or `fern/` | Publishes a preview, upserts a PR comment with the URL plus deep links to each changed page |
| `cleanup-preview.yaml` | `pull_request` closed | Deletes the preview when the PR merged |
| `publish-docs.yaml` | Push to `main`, or manual dispatch | Validates, then publishes the live site |

Notable details:

- **Linting reuses the script, not a copy of it.** `lint-docs.yaml` invokes
  `scripts/docs-lint.sh` directly, so CI and `just docs-lint` cannot drift.
  It has no `paths` filter on purpose: a skipped path-filtered workflow
  reports no status at all, which would deadlock every non-docs PR once
  this becomes a required check. The preview workflow *can* safely filter
  on `docs/`/`fern/`, because nothing gates on it.
- **Previews are keyed on the head branch name** (`--id "$HEAD_REF"`), so
  every push to a PR updates one URL, and `cleanup-preview.yaml` deletes
  it under that same id on merge. Fern previews never expire on their
  own, which is why the cleanup workflow exists.
- **The PR comment is an upsert** (`comment_tag: preview-docs`), so it is
  edited in place instead of appended on every push, and it now includes
  deep links to each changed page via Fern's `get-slug-for-file` API.
- **Publishing uses the "publish to production" shape.** `fern/docs.yml`
  declares a single instance, so there is no `--instance` flag and no
  staging site. `--force` is omitted because Fern documents that GitHub
  Actions skips the overwrite confirmation automatically.
- **Fork PRs are skipped in both preview workflows.** `pull_request` does
  not expose `FERN_TOKEN` to forks, so those runs would fail red. Fern
  suggests `pull_request_target`; that is deliberately avoided here
  because it would run fork-authored code with access to repository
  secrets. Linting still covers fork PRs through the mirrored
  `pull-request/<n>` branch.
- **Changed-page detection covers `.md`, not just `.mdx`.** Fern's example
  filters `*.mdx`; this repo has 25 `.md` pages under `docs/` and `fern/`
  and zero `.mdx`, so the literal version would never find anything.
- **Removes the now-redundant `markdownlint` job from `ci.yaml`** (and its
  entries in the `core-ci-pass` and commented-out `notify` needs lists),
  since `docs-lint.sh` already runs `rumdl` repo-wide.
- Repoints the docs navbar GitHub link at `dsx-ai-factory/nv-rms` after
  the SCM transfer.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

RCKMANAGER-1403

## Breaking Changes

- [ ] This PR contains breaking changes

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Workflow YAML is not unit-testable, so verification was static analysis
plus local execution of the logic:

- `actionlint` with `shellcheck` reports zero findings on all four new
  workflows. The only remaining findings in the repo are pre-existing
  ones in `ci.yaml` and `notify-build-status.yml`.
- `just docs-lint` passes, and `rumdl` is clean across all 36 files.
- Confirmed `fern check` and `fern check --broken-links --local
  --warnings` both resolve the project from the **repo root**, which is
  the working directory all three Fern-style workflows rely on
  (`docs-lint.sh` does `cd fern`, so this path was not previously
  exercised).
- Verified Fern's URL-scrape regex semantics against their documented
  output, and the changed-page detection against the real repo.
- `just build`, `just docs-api`, and `cargo clippy --workspace
  --all-targets -- -D warnings` all pass.

## Additional Notes

Required before the pipeline is functional:

1. `FERN_TOKEN` must be in scope for `dsx-ai-factory/nv-rms` (repo
   secret, or an org secret scoped to this repo).
2. Branch protection should require the **Lint Docs** check and drop
   **Markdown Lint**.
3. The `linux-amd64-cpu4` runners need egress to `registry.npmjs.org`
   and the Fern API. If that is unavailable, the fallback is running
   these jobs in a `container: dockerhub.nvidia.com/node:24-alpine` via
   the NVIDIA mirror `ci.yaml` already uses.

Reviewer notes and follow-ups:

- `preview-docs.yaml` introduces one third-party action,
  `thollander/actions-comment-pull-request@v2.4.3`, pinned to a tag
  rather than a digest. Worth pinning to a SHA, as the `dsx-*` actions
  are, given CodeQL runs on this repo.
- Publishing no longer waits on linting now that they are separate
  workflows, matching Fern's structure. `publish-docs.yaml` runs its own
  `fern check --broken-links` before going live, so only the `rumdl` and
  `<img>` style checks are non-gating.
- `.markdownlint-cli2.yaml` is retained for editor integrations even
  though the CI job that consumed it is gone; deleting it is a separate
  decision.
- Unrelated and pre-existing: `just test` fails on
  `matching_primary_waits_for_control_plane_convergence`, which fails
  identically on clean `main`. `just check` fails locally only because
  `cargo-deny` is not installed in my environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added documentation previews for eligible pull requests, including links to changed pages.
  - Added automatic preview cleanup when pull requests are closed.
  - Added automated documentation publishing for production updates.

- **Documentation**
  - Documented documentation linting, previews, cleanup, and publishing workflows.
  - Improved broken-link validation and updated the documentation license and navigation link.
  - Updated the documentation platform configuration for improved compatibility.

- **Chores**
  - Simplified continuous integration by removing the documentation lint job.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->