### PR TITLE
docs(fern): Add custom-domain/metadata for live site

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -19,13 +19,13 @@ global-theme: nvidia
 
 instances:
   - url: nvidia-rms.docs.buildwithfern.com/rms
-    # custom-domain: docs.nvidia.com/rms
+    custom-domain: docs.nvidia.com/rms
     multi-source: true
 
 title: NVIDIA Rack Management Service
 
-# metadata:
-#   canonical-host: "docs.nvidia.com/rms"
+metadata:
+  canonical-host: "docs.nvidia.com/rms"
 
 check:
   rules:


### PR DESCRIPTION
# Description

Enables the custom domain and canonical host metadata for the live Fern documentation site by uncommenting the relevant configuration in `fern/docs.yml`. This points the published docs to `docs.nvidia.com/rms` instead of the default `buildwithfern.com` subdomain.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes

- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

Cherry-picked from RackManagementService commit `502d9ccc0ce65be7f1235d6cf64f2c3c173b0e83`. Confirm the Fern build/deploy picks up the custom domain and canonical host correctly once merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Enabled the RMS custom domain for the documentation site.
  - Added canonical host metadata to improve consistent indexing and navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->