### PR TITLE
fix(fern): install npm for GH action

### DIFF
--- a/.github/workflows/preview-docs.yaml
+++ b/.github/workflows/preview-docs.yaml
@@ -42,6 +42,11 @@ jobs:
           persist-credentials: false
           fetch-depth: 0  # origin/main...HEAD diff for the changed-page links
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
       - name: Setup Fern CLI
         uses: fern-api/setup-fern-cli@v1
 

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -33,6 +33,11 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
       - name: Setup Fern CLI
         uses: fern-api/setup-fern-cli@d07601425e9c9ede8745d71ca75c4c462d98755d
 


### PR DESCRIPTION
# Pull Request

Fixes "Install Fern CLI" action step by installing npm first.

## Related Issues
N/A

## Type Of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes such as refactoring, tests, docs, or tooling

## Breaking Changes


- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Manual testing performed
- [x] No testing required

## QA And Release Notes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation preview and publishing workflows to use Node.js 24.
  * Improved reliability for documentation builds and deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->