### PR TITLE
Add public RMS roadmap

### DIFF
--- a/RMS-Roadmap.md
+++ b/RMS-Roadmap.md
@@ -1,0 +1,18 @@
+## Public Roadmap
+
+Hi RMS developers and users!
+
+This roadmap summarizes the current direction for RMS as of September 2026 and beyond. It is directional, not a commitment to ship every item listed. Scope and sequencing will continue to change as we learn from contributors and users.
+
+## v0.10.0 Open Source Release - August 2026
+
+## Q3 2026
+RMS next-gen platform support (Vera Rubin, and above). Dependent on release timelines.
+Additional OEM/ODM support
+Service hardening and OSS stable releases
+
+## Q4 2026
+Standalone RMS - An independent of NICo firmware update layer
+
+## Additional features and items under consideration without committed dates.
+RMS support for single node systems


### PR DESCRIPTION
Adds a directional public roadmap through Q4 2026.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a public roadmap outlining planned development through September 2026.
  - Documented the planned v0.10.0 open-source release and Q3–Q4 2026 priorities.
  - Listed potential future work, including next-generation Vera Rubin support, broader OEM/ODM compatibility, service hardening, stable OSS releases, an independent firmware update layer, and single-node system support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->